### PR TITLE
Add a ratelimiter to rocket use

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,3 +1,6 @@
 #When enabled the player will control the glider via looking around.
 #When disabled the player will control the glider via the movement keys.
 glider_mouse_controls (Mouse Controls) bool true
+
+#Set the delay between rocket uses to avoid insane rocket-spam speeds
+glider_rocket_delay (Rocket Delay) int 10


### PR DESCRIPTION
Add a configurable rate limiter to prevent Mach speeds due to rocket spamming.
Setting the limiter will also set a maximum horizontal speed attainable without diving.